### PR TITLE
feat: SEO metadata audit — add title, description, and OG tags to marketing pages (#204)

### DIFF
--- a/app/(marketing)/changelog/page.tsx
+++ b/app/(marketing)/changelog/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Changelog',
+  description: "What's new in Glyphic — release notes, improvements, and bug fixes.",
+}
 
 export default function ChangelogPage() {
   return (

--- a/app/(marketing)/examples/[slug]/page.tsx
+++ b/app/(marketing)/examples/[slug]/page.tsx
@@ -1,4 +1,25 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+function humaniseSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string }
+}): Promise<Metadata> {
+  const title = humaniseSlug(params.slug)
+  return {
+    title,
+    description: `Explore the ${title} Mermaid diagram example — built and animated with Glyphic.`,
+  }
+}
 
 export default function ExamplePage() {
   return (

--- a/app/(marketing)/examples/page.tsx
+++ b/app/(marketing)/examples/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Examples',
+  description:
+    'Browse interactive Mermaid diagram examples built with Glyphic — from flowcharts and sequence diagrams to animated system maps.',
+}
 
 export default function ExamplesPage() {
   return (

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,5 +1,27 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import LandingPage from '@/components/marketing/LandingPage'
+
+export const metadata: Metadata = {
+  title: { absolute: 'Glyphic — Visual Mermaid Diagram Editor' },
+  description:
+    'Glyphic is the visual editor for Mermaid diagrams. Add animations, status overlays, style blocks, and more — then share with a single link.',
+  openGraph: {
+    title: 'Glyphic — Visual Mermaid Diagram Editor',
+    description:
+      'Add animations, status overlays, and style blocks to your Mermaid diagrams. Share with a single link.',
+    url: 'https://glyphic.cc',
+    siteName: 'Glyphic',
+    images: [{ url: '/og.png', width: 1200, height: 630, alt: 'Glyphic diagram editor' }],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Glyphic — Visual Mermaid Diagram Editor',
+    description: 'The visual editor for Mermaid diagrams.',
+    images: ['/og.png'],
+  },
+}
 
 export default function Page() {
   return (

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Pricing',
+  description: 'Simple, transparent pricing for Glyphic. Start free, upgrade when you need more.',
+}
 
 export default function PricingPage() {
   return (

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'Glyphic Privacy Policy — how we collect, use, and protect your data.',
+}
 
 export default function PrivacyPage() {
   return (

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+  description: 'Glyphic Terms of Service — the rules governing use of the Glyphic platform.',
+}
 
 export default function TermsPage() {
   return (

--- a/app/(marketing)/use-cases/[slug]/page.tsx
+++ b/app/(marketing)/use-cases/[slug]/page.tsx
@@ -1,4 +1,25 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+function humaniseSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string }
+}): Promise<Metadata> {
+  const title = humaniseSlug(params.slug)
+  return {
+    title,
+    description: `Learn how ${title} is tackled with Glyphic — interactive, animated Mermaid diagrams.`,
+  }
+}
 
 export default function UseCasePage() {
   return (

--- a/app/(marketing)/use-cases/page.tsx
+++ b/app/(marketing)/use-cases/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from 'next'
+
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Use Cases',
+  description:
+    'Discover how teams use Glyphic to visualise architectures, incident timelines, onboarding flows, and more.',
+}
 
 export default function UseCasesPage() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation'
-
-export default function Home() {
-  redirect('/docs/getting-started')
-}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Glyphic — Full Documentation
 
-Generated: 2026-04-24T13:50:48.017Z
+Generated: 2026-05-02T17:12:02.839Z
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `export const metadata: Metadata` to all 7 static marketing pages (/, /pricing, /examples, /use-cases, /changelog, /privacy, /terms)
- Adds `export async function generateMetadata` with `humaniseSlug` to the 2 dynamic `[slug]` pages (`/examples/[slug]`, `/use-cases/[slug]`) — derives title/description from URL slug
- Adds full OpenGraph + Twitter card tags to the landing page (`/`)
- Fixes a pre-existing bug: removes stale `app/page.tsx` that was redirecting `/` to `/docs/getting-started`, which was preventing the marketing landing page from being served at `/`
- Root `app/layout.tsx` `metadataBase` confirmed as `https://glyphic.cc` (no change needed)

## Test Plan
- [x] `pnpm lint` passes (only pre-existing fonts warning in layout.tsx, unrelated)
- [x] `pnpm build` succeeds — all 9 marketing routes compile cleanly
- [x] Live server verified: all 7 static pages have correct `<title>` and `<meta name="description">`
- [x] Dynamic slug pages produce humanised titles (e.g. `/examples/flowchart-basics` → `Flowchart Basics — Glyphic`)
- [x] Landing page has `og:title`, `og:description`, `og:image`, `og:url`, `og:type`, `twitter:card`
- [ ] Lighthouse SEO score ≥ 90 on landing and pricing pages (manual verification after deploy)

Closes SmilingArmadillo/mermaid-studio#204